### PR TITLE
Fix up paths for KV to align with new values

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
   define: {
     // ensure that you give these types in `src/vite-end.d.ts`
     GITHUB_RUNTIME_PERMANENT_NAME: JSON.stringify(GITHUB_RUNTIME_PERMANENT_NAME),
-    BASE_KV_SERVICE_URL: JSON.stringify("/kv"),
+    BASE_KV_SERVICE_URL: JSON.stringify("/_spark/kv"),
   },
   server: {
     port: 5000,
@@ -71,11 +71,11 @@ export default defineConfig({
       // Any new endpoints defined in the backend server need to be added here
       // as vite serves the frontend during local development and in the live preview,
       // and needs to know to proxy the endpoints to the backend server.
-      "/kv": {
+      "/_spark/kv": {
         target: "http://localhost:8000",
         changeOrigin: true,
       },
-      "/llm": {
+      "/_spark/llm": {
         target: "http://localhost:8000",
         changeOrigin: true,
       },


### PR DESCRIPTION
Expected paths for the KV client changed with https://github.com/github/workbench-template/commit/c3b2da9f0e8ad8ca50133cc140729c8e398bcb8c#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890dd but this didn't end up over in spark-template as well.