### PR TITLE
Update react-day-picker to version 9.6.7 and add date-fns dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
                 "next-themes": "^0.4.6",
                 "octokit": "^4.1.2",
                 "react": "^19.0.0",
-                "react-day-picker": "^8.10.1",
+                "react-day-picker": "^9.6.7",
                 "react-dom": "^19.0.0",
                 "react-hook-form": "^7.54.2",
                 "react-resizable-panels": "^2.1.7",
@@ -434,6 +434,12 @@
             "engines": {
                 "node": ">=6.9.0"
             }
+        },
+        "node_modules/@date-fns/tz": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
+            "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==",
+            "license": "MIT"
         },
         "node_modules/@esbuild/linux-x64": {
             "version": "0.25.1",
@@ -4043,6 +4049,12 @@
                 "url": "https://github.com/sponsors/kossnocorp"
             }
         },
+        "node_modules/date-fns-jalali": {
+            "version": "4.1.0-0",
+            "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+            "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+            "license": "MIT"
+        },
         "node_modules/debug": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -5528,17 +5540,34 @@
             }
         },
         "node_modules/react-day-picker": {
-            "version": "8.10.1",
-            "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
-            "integrity": "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==",
+            "version": "9.6.7",
+            "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.6.7.tgz",
+            "integrity": "sha512-rCSt6X8FXQWpjykns/azRXjJk3cMSzkzGbDEXuEveFGNZgOjZULdJQ5wsu8Zfyo8ZgPBoYCBKQ5wRrgJfhJGbg==",
             "license": "MIT",
+            "dependencies": {
+                "@date-fns/tz": "1.2.0",
+                "date-fns": "4.1.0",
+                "date-fns-jalali": "4.1.0-0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
             "funding": {
                 "type": "individual",
                 "url": "https://github.com/sponsors/gpbl"
             },
             "peerDependencies": {
-                "date-fns": "^2.28.0 || ^3.0.0",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/react-day-picker/node_modules/date-fns": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+            "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/kossnocorp"
             }
         },
         "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "next-themes": "^0.4.6",
         "octokit": "^4.1.2",
         "react": "^19.0.0",
-        "react-day-picker": "^8.10.1",
+        "react-day-picker": "^9.6.7",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.54.2",
         "react-resizable-panels": "^2.1.7",


### PR DESCRIPTION
Bumped in `github/workbench-template` in https://github.com/github/workbench-template/pull/237.

Resolves us having to run `npm install` with a `-f` force flag. Would also need to be run out on `github/spark-template`.

