### PR TITLE
Set file-syncer to run from spark-template

### DIFF
--- a/.devcontainer/spark.conf
+++ b/.devcontainer/spark.conf
@@ -33,6 +33,7 @@ stderr_logfile=/var/log/spark-designer.err.log
 
 [program:spark-file-syncer]
 command=/usr/local/bin/spark-file-syncer 13000
+directory=/workspaces/spark-template
 autostart=true
 autorestart=true
 stdout_logfile=/var/log/spark-file-syncer.out.log


### PR DESCRIPTION
Towards https://github.com/github/spark/issues/823

https://github.com/github/workbench-sdk/pull/279 removes our lookup on the `GITHUB_REPOSITORY` (which plays badly when export repos) so we need to be strict about where we normally start the file syncer running.