### PR TITLE
Add .azcopy to ignored vite path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
       ignored: [
         "**/prd.md", 
         "**.log", 
-        "**/.azcopy/*",
+        "**/.azcopy/**",
       ],
       awaitWriteFinish: {
         pollInterval: 50,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,7 +46,11 @@ export default defineConfig({
       origin: /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\]|(?:.*\.)?github\.com)(?::\d+)?$/
     },
     watch: {
-      ignored: ["**/prd.md", "**.log"],
+      ignored: [
+        "**/prd.md", 
+        "**.log", 
+        "**/.azcopy/*",
+      ],
       awaitWriteFinish: {
         pollInterval: 50,
         stabilityThreshold: 100,


### PR DESCRIPTION
When vite detects changes to root level files, it forces a full page refresh instead of an hot module reload. Since we periodically include these files in our commit history, we should ignore them for the purposes for vite builds.