### PR TITLE
Adding an error boundary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
                 "react": "^19.0.0",
                 "react-day-picker": "^9.6.7",
                 "react-dom": "^19.0.0",
+                "react-error-boundary": "^6.0.0",
                 "react-hook-form": "^7.54.2",
                 "react-resizable-panels": "^2.1.7",
                 "recharts": "^2.15.1",
@@ -6724,6 +6725,18 @@
             },
             "peerDependencies": {
                 "react": "^19.0.0"
+            }
+        },
+        "node_modules/react-error-boundary": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.0.0.tgz",
+            "integrity": "sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.12.5"
+            },
+            "peerDependencies": {
+                "react": ">=16.13.1"
             }
         },
         "node_modules/react-hook-form": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "react": "^19.0.0",
         "react-day-picker": "^9.6.7",
         "react-dom": "^19.0.0",
+        "react-error-boundary": "^6.0.0",
         "react-hook-form": "^7.54.2",
         "react-resizable-panels": "^2.1.7",
         "recharts": "^2.15.1",

--- a/src/ErrorFallback.tsx
+++ b/src/ErrorFallback.tsx
@@ -1,0 +1,36 @@
+import { Alert, AlertTitle, AlertDescription } from "./components/ui/alert";
+import { Button } from "./components/ui/button";
+
+import { AlertTriangleIcon, RefreshCwIcon } from "lucide-react";
+
+export const ErrorFallback = ({ error, resetErrorBoundary }) => {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <Alert variant="destructive" className="mb-6">
+          <AlertTriangleIcon />
+          <AlertTitle>This spark has encountered a runtime error</AlertTitle>
+          <AlertDescription>
+            Something unexpected happened while running the application. The error details are shown below. Contact the spark author and let them know about this issue.
+          </AlertDescription>
+        </Alert>
+        
+        <div className="bg-card border rounded-lg p-4 mb-6">
+          <h3 className="font-semibold text-sm text-muted-foreground mb-2">Error Details:</h3>
+          <pre className="text-xs text-destructive bg-muted/50 p-3 rounded border overflow-auto max-h-32">
+            {error.message}
+          </pre>
+        </div>
+        
+        <Button 
+          onClick={resetErrorBoundary} 
+          className="w-full"
+          variant="outline"
+        >
+          <RefreshCwIcon />
+          Try Again
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,16 @@
-import React from 'react'
 import { createRoot } from 'react-dom/client'
+import { ErrorBoundary } from "react-error-boundary";
+import "@github/spark/spark"
+
 import App from './App.tsx'
+import { ErrorFallback } from './ErrorFallback.tsx'
+
 import "./main.css"
 import "./styles/theme.css"
 import "./index.css"
-import "@github/spark/spark"
 
 createRoot(document.getElementById('root')!).render(
+  <ErrorBoundary FallbackComponent={ErrorFallback}>
     <App />
+   </ErrorBoundary>
 )


### PR DESCRIPTION
Adds an ErrorBoundary object to catch render errors that may occur. This is a fallback for when the app code is not built with its own error handling.

![Screenshot 2025-06-24 at 10 37 28 PM](https://github.com/user-attachments/assets/74b7de1f-9788-4730-9c76-684e675f56ce)
