### PR TITLE
Rethrow error from ErrorFallback

### DIFF
--- a/src/ErrorFallback.tsx
+++ b/src/ErrorFallback.tsx
@@ -4,6 +4,10 @@ import { Button } from "./components/ui/button";
 import { AlertTriangleIcon, RefreshCwIcon } from "lucide-react";
 
 export const ErrorFallback = ({ error, resetErrorBoundary }) => {
+  // When encountering an error in the development mode, rethrow it and don't display the boundary.
+  // The parent UI will take care of showing a more helpful dialog.
+  if (import.meta.env.DEV) throw error;
+
   return (
     <div className="min-h-screen bg-background flex items-center justify-center p-4">
       <div className="w-full max-w-md">


### PR DESCRIPTION
When this Spark is being edited in development, rethrow the error for it to be caught by the parent container. In deployed sparks, the error boundary will be shown.