### PR TITLE
🎇 Add strictNullChecks to the tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     ],
     "module": "ESNext",
     "skipLibCheck": true,
+    "strictNullChecks": true,
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
Currently we ignore `null | undefined` returns in `useKV`, even though the types explicitly list `T | undefined` as part of the return. This change surfaces that possible undefined to the user so it can be resolved by them or the agent in a visible way.