### PR TITLE
🎇 Fix calendar.tsx typescript errors

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -59,10 +59,10 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        IconLeft: ({ className, ...props }) => (
+        PreviousMonthButton: ({ className, ...props }) => (
           <ChevronLeft className={cn("size-4", className)} {...props} />
         ),
-        IconRight: ({ className, ...props }) => (
+        NextMonthButton: ({ className, ...props }) => (
           <ChevronRight className={cn("size-4", className)} {...props} />
         ),
       }}


### PR DESCRIPTION
We were passing `IconLeft` and `IconRight` to the `react-day-picker` component, when those aren't actually options in the components prop. Per https://daypicker.dev/api/type-aliases/CustomComponents, it looks like what we should've used is PreviousMonthButton and NextMonthButton. Confirmed in a prod codespace editing calendar.tsx directly that this does render the correct icons.

This was the only tsc error that comes up when running `npx tsc` from the built-in components, so resolving issues with generated code should be easier without the noise

|before|after|
|---|---|
|![Screenshot 2025-07-03 at 1 50 03 PM](https://github.com/user-attachments/assets/f0164d47-5587-4c93-b292-56a23fe44544)|![Screenshot 2025-07-03 at 1 49 38 PM](https://github.com/user-attachments/assets/f460c0b6-0309-4a84-ae16-ac4df1f7a50a)|