### PR TITLE
Setup post-commit hook to withstand template based creations

### DIFF
--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -22,5 +22,6 @@ supervisord
 supervisorctl reread
 supervisorctl update
 
-# Run the build script to perform a one-time build for static preview
+# Set up post-commit hook and also run the build script to perform a one-time build for static preview
+ln -fs /usr/local/bin/post-commit .git/hooks/pre-push
 /usr/local/bin/static-preview-build.sh

--- a/.devcontainer/refreshTools.sh
+++ b/.devcontainer/refreshTools.sh
@@ -45,7 +45,7 @@ sudo cp ./spark-sdk-dist/proxy.js /workspaces/proxy.js
 sudo mv ./spark-sdk-dist/proxy.js  /usr/local/bin/proxy.js
 sudo mv ./spark-sdk-dist/spark.package.json /workspaces/spark.package.json 
 sudo mv ./spark-sdk-dist/static-preview-build.sh /usr/local/bin/static-preview-build.sh
-sudo mv ./spark-sdk-dist/post-commit ${WORKSPACE_DIR}/.git/hooks/post-commit
+sudo mv ./spark-sdk-dist/post-commit /usr/local/bin/post-commit
 
 # Upgrade the Spark Tools package
 if [ -f "$TOOLS_MARKER_FILE" ] && [ "$(cat "$TOOLS_MARKER_FILE")" == "$(cat ./spark-sdk-dist/spark-tools-version)" ]; then


### PR DESCRIPTION
Setup post-commit on postCreateCommand, because git directory may be reset if when the repo is used as template