### PR TITLE
Update .gitignore to ignore .spark-workbench-id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ dist-ssr
 packages
 .file-manifest
 .devcontainer/
+
+.spark-workbench-id


### PR DESCRIPTION
Add .spark-workbench-id to .gitignore