### PR TITLE
Test creating Commit

### DIFF
--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -1,5 +1,31 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LATEST_RELEASE=$(bash "$SCRIPT_DIR/refreshTools.sh")
+
+sudo cp .devcontainer/spark.conf /etc/supervisor/conf.d/
+
+# Check git repository state and create initial commit if needed
+cd /workspaces/spark-template
+echo "Checking git repository state"
+if ! git rev-parse HEAD >/dev/null 2>&1; then
+    echo "No commits found, creating initial commit"
+    git add . || true
+    git commit --allow-empty --no-verify -m "Initial commit" --no-gpg-sign || true
+fi 
+
+cd /tmp/spark
+bash spark-sdk-dist/repair.sh
+LATEST_RELEASE="$LATEST_RELEASE" WORKSPACE_DIR="$WORKSPACE_DIR" bash /tmp/spark/spark-sdk-dist/install-tools.sh services
+cd /workspaces/spark-template
+
+sudo chown node /var/run/
+sudo chown -R node /var/log/
+
+supervisord
+supervisorctl reread
+supervisorctl update
+
 # Check if SNAPSHOT_SAS_URL was passed, if so run hydrate.sh
 if [ -n "$SNAPSHOT_SAS_URL" ]; then
     WORKSPACE_DIR="/workspaces/spark-template"


### PR DESCRIPTION
We have encountered an issue where the command git rev-parse HEAD fails for users with GPG signing enabled. This appears to be caused by the initial commit failing with a 403 error when attempting to sign the commit, as GPG signing requires push access to the repository. To address this and ensure an initial commit is always present, we will implement a check to verify whether a commit has been created; if not, we will proceed to create one.