### PR TITLE
Update baseUrl and paths in tsconfig.json

### DIFF
--- a/spark.meta.json
+++ b/spark.meta.json
@@ -1,3 +1,3 @@
 {
-    "templateVersion": 0
+    "templateVersion": 1
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,10 +21,9 @@
     /* Linting */
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": [
-        "src/*"
+        "./src/*"
       ]
     },
   },


### PR DESCRIPTION
With updates to start using `tsgo` we are seeing the following class of errors:

```tsconfig.json:24:5 - error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
  Use '"paths": {"*": "./*"}' instead.

24     "baseUrl": ".",
       ~~~~~~~~~
tsconfig.json:27:9 - error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?

27         "src/*"
           ~~~~~~~

Found 2 errors in the same file, starting at: tsconfig.json:24```

https://www.typescriptlang.org/tsconfig/#baseUrl
> As of TypeScript 4.1, baseUrl is no longer required to be set when using paths.