### PR TITLE
Bump vulnerable npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
                 "tailwind-merge": "^3.0.2",
                 "three": "^0.175.0",
                 "tw-animate-css": "^1.2.4",
-                "uuid": "^11.1.0",
+                "uuid": "^11.1.1",
                 "vaul": "^1.1.2",
                 "zod": "^3.25.76"
             },
@@ -6992,11 +6992,10 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+            "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -8215,14 +8214,13 @@
             }
         },
         "node_modules/uuid": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
             ],
-            "license": "MIT",
             "bin": {
                 "uuid": "dist/esm/bin/uuid"
             }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "tailwind-merge": "^3.0.2",
         "three": "^0.175.0",
         "tw-animate-css": "^1.2.4",
-        "uuid": "^11.1.0",
+        "uuid": "^11.1.1",
         "vaul": "^1.1.2",
         "zod": "^3.25.76"
     },
@@ -98,6 +98,15 @@
         "picomatch": "4.0.4",
         "path-to-regexp": "8.4.0",
         "lodash": "4.18.0",
+        "eslint": {
+            "minimatch": "3.1.3"
+        },
+        "@eslint/config-array": {
+            "minimatch": "3.1.3"
+        },
+        "@eslint/eslintrc": {
+            "minimatch": "3.1.3"
+        },
         "@typescript-eslint/typescript-estree": {
             "minimatch": "9.0.7"
         }


### PR DESCRIPTION
## Summary
- pin ESLint's transitive `minimatch` resolution to `3.1.3`
- bump direct `uuid` dependency to `11.1.1`
- refresh the lockfile to capture both patched versions
